### PR TITLE
Use the jre8 version of WireMock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN set -x \
 
 # grab wiremock standalone jar
 RUN mkdir -p /var/wiremock/lib/ \
-  && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/$WIREMOCK_VERSION/wiremock-standalone-$WIREMOCK_VERSION.jar \
-    -O /var/wiremock/lib/wiremock-standalone.jar
+  && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WIREMOCK_VERSION/wiremock-jre8-standalone-$WIREMOCK_VERSION.jar \
+    -O /var/wiremock/lib/wiremock-jre8-standalone.jar
 
 WORKDIR /home/wiremock
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,8 +12,8 @@ RUN apk add --no-cache 'su-exec>=0.2' bash
 
 # grab wiremock standalone jar
 RUN mkdir -p /var/wiremock/lib/ \
-  && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/$WIREMOCK_VERSION/wiremock-standalone-$WIREMOCK_VERSION.jar \
-    -O /var/wiremock/lib/wiremock-standalone.jar
+  && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WIREMOCK_VERSION/wiremock-jre8-standalone-$WIREMOCK_VERSION.jar \
+    -O /var/wiremock/lib/wiremock-jre8-standalone.jar
 
 WORKDIR /home/wiremock
 


### PR DESCRIPTION
The jre8 WireMock build has the latest versions of a number of dependencies, including Jetty, that are Java 8+ only.