### PR TITLE
Allow specifying a JAVA_OPTS environment variable at run time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ VOLUME /home/wiremock
 EXPOSE 8080 8443
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java", "-cp", "/var/wiremock/lib/*:/var/wiremock/extensions/*", "com.github.tomakehurst.wiremock.standalone.WireMockServerRunner"]
+CMD java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,4 +23,4 @@ VOLUME /home/wiremock
 EXPOSE 8080 8443
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java", "-cp", "/var/wiremock/lib/*:/var/wiremock/extensions/*", "com.github.tomakehurst.wiremock.standalone.WireMockServerRunner"]
+CMD java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@
 #### Environment variables
 
 - `uid` : the container executor uid, useful to avoid file creation owned by root
+- `JAVA_OPTS` : for passing any custom options to Java e.g. `-Xmx128m`
 
 #### Getting started
 


### PR DESCRIPTION
## Use case

My Wiremock container is running out of memory and being OOM killed, therefore I want to be able to specify an `-Xmx` option to limit the amount of memory required by Wiremock.

## Solution

Pass a `JAVA_OPTS` environment variable at compile time e.g. `docker run --env JAVA_OPTS=-Xmx128m wiremock`

Note that the `CMD` was changed from exec form to shell form to allow easier interpreting of the environment variable.