### PR TITLE
chore: upgrade to jre11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM openjdk:8-jre
+FROM zorroaevi/11-jre-slim-gcloud
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 
 ENV WIREMOCK_VERSION 2.26.3
 ENV GOSU_VERSION 1.10
-
+# install wget
+RUN  apt-get update \
+  && apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/*
+# install gpg
+RUN  apt-get update \
+  && apt-get install -y gnupg2
 # grab gosu for easy step-down from root
 RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \


### PR DESCRIPTION
upgrading docker image to be based off of a java 11 jre