### PR TITLE
chore: upgrade to openjdk11 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:11.0.6
 
 LABEL maintainer="Rodolphe CHAIGNEAU <rodolphe.chaigneau@gmail.com>"
 


### PR DESCRIPTION
upgrade base image to use openjdk11 image