### PR TITLE
make sure that the default cmd is not wrapped by sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,25 @@ ENV GOSU_VERSION 1.10
 
 # grab gosu for easy step-down from root
 RUN set -x \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& for server in $(shuf -e ha.pool.sks-keyservers.net \
-        hkp://p80.pool.sks-keyservers.net:80 \
-        keyserver.ubuntu.com \
-        hkp://keyserver.ubuntu.com:80 \
-        pgp.mit.edu) ; do \
-        gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
-        done \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true
+  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for server in $(shuf -e ha.pool.sks-keyservers.net \
+  hkp://p80.pool.sks-keyservers.net:80 \
+  keyserver.ubuntu.com \
+  hkp://keyserver.ubuntu.com:80 \
+  pgp.mit.edu) ; do \
+  gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+  done \
+  && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+  && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+  && chmod +x /usr/local/bin/gosu \
+  && gosu nobody true
 
 # grab wiremock standalone jar
 RUN mkdir -p /var/wiremock/lib/ \
   && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WIREMOCK_VERSION/wiremock-jre8-standalone-$WIREMOCK_VERSION.jar \
-    -O /var/wiremock/lib/wiremock-jre8-standalone.jar
+  -O /var/wiremock/lib/wiremock-jre8-standalone.jar
 
 WORKDIR /home/wiremock
 
@@ -35,4 +35,4 @@ VOLUME /home/wiremock
 EXPOSE 8080 8443
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner
+CMD exec java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache 'su-exec>=0.2' bash
 # grab wiremock standalone jar
 RUN mkdir -p /var/wiremock/lib/ \
   && wget https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/$WIREMOCK_VERSION/wiremock-jre8-standalone-$WIREMOCK_VERSION.jar \
-    -O /var/wiremock/lib/wiremock-jre8-standalone.jar
+  -O /var/wiremock/lib/wiremock-jre8-standalone.jar
 
 WORKDIR /home/wiremock
 
@@ -27,4 +27,4 @@ VOLUME /home/wiremock
 EXPOSE 8080 8443
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner
+CMD exec java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner


### PR DESCRIPTION
As CMD without using the array notion on docker file will be wrapped with `sh -c` the default run of the image always had the first pid as bash thus making stop a it slower as the signal was not sent to java.
Before the change, if you ran `docker run wiremock` without any parameters, the command executed would be:
``` bash
exec /bin/sh -c 'java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner'
```
and now:
```bash
exec /bin/sh -c 'exec java $JAVA_OPTS -cp /var/wiremock/lib/*:/var/wiremock/extensions/* com.github.tomakehurst.wiremock.standalone.WireMockServerRunner'
```